### PR TITLE
Use multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust:1-alpine
-EXPOSE 8080
+FROM rust:1-alpine AS builder
 
 RUN apk add --no-cache musl-dev
 
@@ -16,4 +15,12 @@ RUN cargo build-deps --release
 COPY src ./src
 RUN cargo build --release
 
-CMD cargo run --release
+FROM alpine:3 AS runtime
+
+EXPOSE 8080
+
+WORKDIR /app
+
+COPY --from=builder /app/bw_masterserver/target/release ./
+
+CMD ["/app/bw_master_server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     links:
       - redis # links this container to "redis" container
     volumes:
-      - './bw_master_server.toml:/app/bw_masterserver/bw_master_server.toml'
+      - './bw_master_server.toml:/app/bw_master_server.toml'
 
 networks:
   burgwar:


### PR DESCRIPTION
The Rust toolchain is not required during runtime so using multistage build can reduce the size of the final image: 1.64 GB original reduced to 620 MB